### PR TITLE
RDK-57093: Update Plugin Clients to use update Power manager interface

### DIFF
--- a/FrontPanel/FrontPanel.cpp
+++ b/FrontPanel/FrontPanel.cpp
@@ -244,7 +244,7 @@ namespace WPEFramework
             registerEventHandlers();
         }
 
-        void FrontPanel::onPowerModeChanged(const PowerState &currentState, const PowerState &newState)
+        void FrontPanel::onPowerModeChanged(const PowerState currentState, const PowerState newState)
         {
             if(newState == WPEFramework::Exchange::IPowerManager::POWER_STATE_ON)
             {

--- a/FrontPanel/FrontPanel.h
+++ b/FrontPanel/FrontPanel.h
@@ -98,7 +98,7 @@ namespace WPEFramework {
                 ~PowerManagerNotification() override = default;
             
             public:
-                void OnPowerModeChanged(const PowerState &currentState, const PowerState &newState) override
+                void OnPowerModeChanged(const PowerState currentState, const PowerState newState) override
                 {
                     _parent.onPowerModeChanged(currentState, newState);
                 }
@@ -164,7 +164,7 @@ namespace WPEFramework {
             virtual const string Initialize(PluginHost::IShell* shell) override;
             virtual void Deinitialize(PluginHost::IShell* service) override;
             virtual string Information() const override { return {}; }
-            void onPowerModeChanged(const PowerState &currentState, const PowerState &newState);
+            void onPowerModeChanged(const PowerState currentState, const PowerState newState);
             void updateLedTextPattern();
             void registerEventHandlers();
 


### PR DESCRIPTION
Reason for change: Interface API arguments should not be passed by reference if they are primitive data types.
Test Procedure: unit test 
Risks: LOW