### PR TITLE
RDK-57093: PowerManager Interface methods and event APIs modified

### DIFF
--- a/helpers/frontpanel.cpp
+++ b/helpers/frontpanel.cpp
@@ -160,7 +160,7 @@ namespace WPEFramework
 
 #if defined(HAS_API_POWERSTATE)
                     {
-                        uint32_t res = Core::ERROR_GENERAL;
+                        Core::hresult res = Core::ERROR_GENERAL;
                         PowerState pwrStateCur = WPEFramework::Exchange::IPowerManager::POWER_STATE_UNKNOWN;
                         PowerState pwrStatePrev = WPEFramework::Exchange::IPowerManager::POWER_STATE_UNKNOWN;
                         ASSERT (_powerManagerPlugin);


### PR DESCRIPTION
RDK-57093: PowerManager Interface methods and event APIs modified

Reason for changes: The Interface method return type and event APIs are modified as per API spec
Test procedure: Full stack build
Risk: Low