### PR TITLE
RDKEMW-4140: Coverity integration with Entservices-peripherals repo

### DIFF
--- a/cov_build.sh
+++ b/cov_build.sh
@@ -31,6 +31,9 @@ cmake -G Ninja -S "$GITHUB_WORKSPACE" -B build/entservices-peripherals \
 -I ${GITHUB_WORKSPACE}/entservices-testframework/Tests/headers/rdk/iarmmgrs-hal \
 -I ${GITHUB_WORKSPACE}/entservices-testframework/Tests/headers/ccec/drivers \
 -I ${GITHUB_WORKSPACE}/entservices-testframework/Tests/headers/network \
+-I ${GITHUB_WORKSPACE}/entservices-testframework/Tests/mocks \
+-I ${GITHUB_WORKSPACE}/entservices-testframework/Tests/mocks/thunder \
+-I ${GITHUB_WORKSPACE}/entservices-testframework/Tests/mocks/devicesettings \
 -include ${GITHUB_WORKSPACE}/entservices-testframework/Tests/mocks/devicesettings.h \
 -include ${GITHUB_WORKSPACE}/entservices-testframework/Tests/mocks/Iarm.h \
 -include ${GITHUB_WORKSPACE}/entservices-testframework/Tests/mocks/Rfc.h \

--- a/cov_build.sh
+++ b/cov_build.sh
@@ -46,7 +46,7 @@ cmake -G Ninja -S "$GITHUB_WORKSPACE" -B build/entservices-peripherals \
 -include ${GITHUB_WORKSPACE}/entservices-testframework/Tests/mocks/wpa_ctrl_mock.h \
 -include ${GITHUB_WORKSPACE}/entservices-testframework/Tests/mocks/secure_wrappermock.h \
 -include ${GITHUB_WORKSPACE}/entservices-testframework/Tests/mocks/MotionDetection.h \
---coverage -Wall -Werror -Wno-error=format \
+-Wall -Werror -Wno-error=format \
 -Wl,-wrap,system -Wl,-wrap,popen -Wl,-wrap,syslog \
 -DENABLE_TELEMETRY_LOGGING -DUSE_IARMBUS \
 -DENABLE_SYSTEM_GET_STORE_DEMO_LINK -DENABLE_DEEP_SLEEP \


### PR DESCRIPTION
Reason for change: Coverity integration with middleware component workflow 
Test Procedure: Verify checks in github
Risks: Low
Signed-off-by:AkshayKumar_Gampa AkshayKumar_Gampa@comcast.com