### PR TITLE
RDK-55477 : Add L1 / L2 tests for LEDControl plugin (#46)

### DIFF
--- a/.github/workflows/L2-tests.yml
+++ b/.github/workflows/L2-tests.yml
@@ -1,0 +1,603 @@
+name: L2-tests
+
+on:
+  push:
+    branches: [ main, develop, 'sprint/**', 'release/**' ]
+  pull_request:
+    branches: [ main, develop, 'sprint/**', 'release/**' ]
+
+env:
+  BUILD_TYPE: Debug
+  THUNDER_REF: "R4.4.1"
+  INTERFACES_REF: "develop"
+  AUTOMATICS_UNAME: ${{ secrets.AUTOMATICS_UNAME}}
+  AUTOMATICS_PASSCODE: ${{ secrets. AUTOMATICS_PASSCODE}}
+
+jobs:
+  L2-tests:
+    name: Build and run L2 tests
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        compiler: [ gcc, clang ]
+        coverage: [ with-coverage, without-coverage ]
+        exclude:
+          - compiler: clang
+            coverage: with-coverage
+          - compiler: clang
+            coverage: without-coverage
+          - compiler: gcc
+            coverage: without-coverage
+
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - run: pip install jsonref
+
+      - name: Set up CMake
+        uses: jwlawson/actions-setup-cmake@v1.13
+        with:
+          cmake-version: '3.16.x'
+
+      - name: Install packages
+        run: >
+          sudo apt update
+          &&
+          sudo apt install -y libsqlite3-dev libcurl4-openssl-dev valgrind lcov clang libsystemd-dev libboost-all-dev libwebsocketpp-dev meson libcunit1 libcunit1-dev curl protobuf-compiler-grpc libgrpc-dev libgrpc++-dev libdbus-1-dev
+
+      - name: Install GStreamer
+        run: |
+           sudo apt update
+           sudo apt install -y libunwind-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev
+
+      - name: Build trower-base64
+        run: |
+            if [ ! -d "trower-base64" ]; then
+            git clone https://github.com/xmidt-org/trower-base64.git
+            fi
+            cd trower-base64
+            meson setup --warnlevel 3 --werror build
+            ninja -C build
+            sudo ninja -C build install
+
+      - name: Checkout Thunder
+        uses: actions/checkout@v3
+        with:
+          repository: rdkcentral/Thunder
+          path: Thunder
+          ref: ${{env.THUNDER_REF}}
+
+      - name: Checkout ThunderTools
+        uses: actions/checkout@v3
+        with:
+          repository: rdkcentral/ThunderTools
+          path: ThunderTools
+          ref: R4.4.3
+          
+      - name: Checkout entservices-peripherals
+        uses: actions/checkout@v3
+        with:
+          path: entservices-peripherals                
+
+      - name: Checkout entservices-testframework
+        uses: actions/checkout@v3
+        with:
+          repository: rdkcentral/entservices-testframework
+          path: entservices-testframework
+          ref: develop 
+          token: ${{ secrets.RDKCM_RDKE }}
+
+      - name: Checkout googletest
+        if: steps.cache.outputs.cache-hit != 'true'
+        uses: actions/checkout@v3
+        with:
+          repository: google/googletest
+          path: googletest
+          ref: v1.15.0    
+
+      - name: Apply patches ThunderTools
+        run: |  
+          cd $GITHUB_WORKSPACE/ThunderTools
+          patch -p1 < $GITHUB_WORKSPACE/entservices-testframework/patches/00010-R4.4-Add-support-for-project-dir.patch
+          cd -
+
+      - name: Build ThunderTools
+        run: >
+          cmake
+          -S "$GITHUB_WORKSPACE/ThunderTools"
+          -B build/ThunderTools
+          -DEXCEPTIONS_ENABLE=ON
+          -DCMAKE_INSTALL_PREFIX="$GITHUB_WORKSPACE/install/usr"
+          -DCMAKE_MODULE_PATH="$GITHUB_WORKSPACE/install/tools/cmake"
+          -DGENERIC_CMAKE_MODULE_PATH="$GITHUB_WORKSPACE/install/tools/cmake"
+          &&
+          cmake --build build/ThunderTools -j8
+          &&
+          cmake --install build/ThunderTools
+
+      - name: Apply patches Thunder
+        run: |
+          cd $GITHUB_WORKSPACE/Thunder
+          patch -p1 < $GITHUB_WORKSPACE/entservices-testframework/patches/Use_Legact_Alt_Based_On_ThunderTools_R4.4.3.patch
+          patch -p1 < $GITHUB_WORKSPACE/entservices-testframework/patches/error_code_R4_4.patch
+          patch -p1 < $GITHUB_WORKSPACE/entservices-testframework/patches/1004-Add-support-for-project-dir.patch
+          patch -p1 < $GITHUB_WORKSPACE/entservices-testframework/patches/RDKEMW-733-Add-ENTOS-IDS.patch
+          cd -
+
+      - name: Build Thunder
+        run: >
+          cmake
+          -S "$GITHUB_WORKSPACE/Thunder"
+          -B build/Thunder
+          -DMESSAGING=ON
+          -DCMAKE_INSTALL_PREFIX="$GITHUB_WORKSPACE/install/usr"
+          -DCMAKE_MODULE_PATH="$GITHUB_WORKSPACE/install/tools/cmake"
+          -DGENERIC_CMAKE_MODULE_PATH="$GITHUB_WORKSPACE/install/tools/cmake"
+          -DBUILD_TYPE=${{env.BUILD_TYPE}}
+          -DBINDING=127.0.0.1
+          -DPORT=9998
+          -DEXCEPTIONS_ENABLE=ON
+          &&
+          cmake --build build/Thunder -j8
+          &&
+          cmake --install build/Thunder
+
+      - name: Checkout entservices-apis
+        uses: actions/checkout@v3
+        with:
+          repository: rdkcentral/entservices-apis
+          path: entservices-apis
+          ref: ${{env.INTERFACES_REF}}
+          run: rm -rf $GITHUB_WORKSPACE/entservices-apis/jsonrpc/DTV.json
+
+      - name: Apply patches entservices-apis
+        run: |
+          cd $GITHUB_WORKSPACE/entservices-apis
+          patch -p1 < $GITHUB_WORKSPACE/entservices-testframework/patches/RDKEMW-1007.patch
+          cd -      
+
+      - name: Build entservices-apis
+        run: >
+          cmake
+          -S "$GITHUB_WORKSPACE/entservices-apis"
+          -B build/entservices-apis
+          -DEXCEPTIONS_ENABLE=ON
+          -DCMAKE_INSTALL_PREFIX="$GITHUB_WORKSPACE/install/usr"
+          -DCMAKE_MODULE_PATH="$GITHUB_WORKSPACE/install/tools/cmake"
+          &&
+          cmake --build build/entservices-apis -j8
+          &&
+          cmake --install build/entservices-apis
+
+      - name: Generate external headers
+        # Empty headers to mute errors
+        run: >
+          cd "$GITHUB_WORKSPACE/entservices-testframework/Tests/"
+          &&
+          mkdir -p
+          headers
+          headers/audiocapturemgr
+          headers/rdk/ds
+          headers/rdk/iarmbus
+          headers/rdk/iarmmgrs-hal
+          headers/rdk/halif/
+          headers/rdk/halif/deepsleep-manager
+          headers/ccec/drivers
+          headers/network
+          headers/proc
+          &&
+          cd headers
+          &&
+          touch
+          audiocapturemgr/audiocapturemgr_iarm.h
+          ccec/drivers/CecIARMBusMgr.h
+          rdk/ds/audioOutputPort.hpp
+          rdk/ds/compositeIn.hpp
+          rdk/ds/dsDisplay.h
+          rdk/ds/dsError.h
+          rdk/ds/dsMgr.h
+          rdk/ds/dsTypes.h
+          rdk/ds/dsUtl.h
+          rdk/ds/exception.hpp
+          rdk/ds/hdmiIn.hpp
+          rdk/ds/host.hpp
+          rdk/ds/list.hpp
+          rdk/ds/manager.hpp
+          rdk/ds/sleepMode.hpp
+          rdk/ds/videoDevice.hpp
+          rdk/ds/videoOutputPort.hpp
+          rdk/ds/videoOutputPortConfig.hpp
+          rdk/ds/videoOutputPortType.hpp
+          rdk/ds/videoResolution.hpp
+          rdk/ds/frontPanelIndicator.hpp
+          rdk/ds/frontPanelConfig.hpp
+          rdk/ds/frontPanelTextDisplay.hpp
+          rdk/iarmbus/libIARM.h
+          rdk/iarmbus/libIBus.h
+          rdk/iarmbus/libIBusDaemon.h
+          rdk/halif/deepsleep-manager/deepSleepMgr.h
+          rdk/iarmmgrs-hal/mfrMgr.h
+          rdk/iarmmgrs-hal/pwrMgr.h
+          rdk/iarmmgrs-hal/sysMgr.h
+          network/wifiSrvMgrIarmIf.h
+          network/netsrvmgrIarm.h
+          libudev.h
+          rfcapi.h
+          rbus.h
+          motionDetector.h
+          telemetry_busmessage_sender.h
+          maintenanceMGR.h
+          pkg.h
+          secure_wrapper.h
+          wpa_ctrl.h
+          proc/readproc.h
+          systemaudioplatform.h
+          gdialservice.h
+          gdialservicecommon.h
+          rdk/ds/audioOutputPort.hpp
+          rdk/ds/audioOutputPortType.hpp
+          rdk/ds/AudioStereoMode.hpp
+          rdk/ds/VideoDFC.hpp
+          &&
+          cp -r /usr/include/gstreamer-1.0/gst /usr/include/glib-2.0/* /usr/lib/x86_64-linux-gnu/glib-2.0/include/* /usr/local/include/trower-base64/base64.h .
+
+      - name: Set clang toolchain
+        if: ${{ matrix.compiler == 'clang' }}
+        run: echo "TOOLCHAIN_FILE=$GITHUB_WORKSPACE/entservices-testframework/Tests/clang.cmake" >> $GITHUB_ENV
+
+      - name: Set gcc/with-coverage toolchain
+        if: ${{ matrix.compiler == 'gcc' && matrix.coverage == 'with-coverage' && !env.ACT }}
+        run: echo "TOOLCHAIN_FILE=$GITHUB_WORKSPACE/entservices-testframework/Tests/gcc-with-coverage.cmake" >> $GITHUB_ENV
+
+      - name: Build mocks
+        run: >
+          cmake
+          -S "$GITHUB_WORKSPACE/entservices-testframework/Tests/mocks"
+          -B build/mocks
+          -DBUILD_SHARED_LIBS=ON
+          -DUSE_THUNDER_R4=ON
+          -DCMAKE_TOOLCHAIN_FILE="${{ env.TOOLCHAIN_FILE }}"
+          -DCMAKE_INSTALL_PREFIX="$GITHUB_WORKSPACE/install/usr"
+          -DCMAKE_MODULE_PATH="$GITHUB_WORKSPACE/install/tools/cmake"
+          -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+          -DCMAKE_CXX_FLAGS="
+          -I $GITHUB_WORKSPACE/entservices-testframework/Tests/headers"
+          &&
+          cmake --build build/mocks -j8
+          &&
+          cmake --install build/mocks
+
+      - name: Build googletest
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: >
+          cmake -G Ninja
+          -S "$GITHUB_WORKSPACE/googletest"
+          -B build/googletest
+          -DCMAKE_INSTALL_PREFIX="$GITHUB_WORKSPACE/install/usr"
+          -DCMAKE_MODULE_PATH="$GITHUB_WORKSPACE/install/tools/cmake"
+          -DGENERIC_CMAKE_MODULE_PATH="$GITHUB_WORKSPACE/install/tools/cmake"
+          -DBUILD_TYPE=Debug
+          -DBUILD_GMOCK=ON
+          &&
+          cmake --build build/googletest -j8
+          &&
+          cmake --install build/googletest    
+
+      - name: Build entservices-peripherals
+        run: >
+          cmake
+          -S "$GITHUB_WORKSPACE/entservices-peripherals"
+          -B build/entservices-peripherals
+          -DCMAKE_INSTALL_PREFIX="$GITHUB_WORKSPACE/install/usr"
+          -DCMAKE_MODULE_PATH="$GITHUB_WORKSPACE/install/tools/cmake"
+          -DCMAKE_CXX_FLAGS="
+          -fprofile-arcs
+          -ftest-coverage
+          -DEXCEPTIONS_ENABLE=ON
+          -DUSE_THUNDER_R4=ON
+          -DTHUNDER_VERSION=4
+          -DTHUNDER_VERSION_MAJOR=4
+          -DTHUNDER_VERSION_MINOR=4
+          -DRDK_SERVICE_L2_TEST
+          -I $GITHUB_WORKSPACE/entservices-testframework/Tests/headers
+          -I $GITHUB_WORKSPACE/entservices-testframework/Tests/headers/audiocapturemgr
+          -I $GITHUB_WORKSPACE/entservices-testframework/Tests/headers/rdk/ds
+          -I $GITHUB_WORKSPACE/entservices-testframework/Tests/headers/rdk/iarmbus
+          -I $GITHUB_WORKSPACE/entservices-testframework/Tests/headers/rdk/iarmmgrs-hal
+          -I $GITHUB_WORKSPACE/entservices-testframework/Tests/headers/ccec/drivers
+          -I $GITHUB_WORKSPACE/entservices-testframework/Tests/headers/network
+          -I $GITHUB_WORKSPACE/entservices-testframework/Tests
+          -I $GITHUB_WORKSPACE/Thunder/Source
+          -I $GITHUB_WORKSPACE/Thunder/Source/core
+          -I $GITHUB_WORKSPACE/install/usr/include
+          -I $GITHUB_WORKSPACE/install/usr/include/WPEFramework
+          -I $GITHUB_WORKSPACE/entservices-testframework/Tests/mocks
+          -include $GITHUB_WORKSPACE/entservices-testframework/Tests/mocks/devicesettings.h
+          -include $GITHUB_WORKSPACE/entservices-testframework/Tests/mocks/Iarm.h
+          -include $GITHUB_WORKSPACE/entservices-testframework/Tests/mocks/Rfc.h
+          -include $GITHUB_WORKSPACE/entservices-testframework/Tests/mocks/RBus.h
+          -include $GITHUB_WORKSPACE/entservices-testframework/Tests/mocks/Telemetry.h
+          -include $GITHUB_WORKSPACE/entservices-testframework/Tests/mocks/Udev.h
+          -include $GITHUB_WORKSPACE/entservices-testframework/Tests/mocks/maintenanceMGR.h
+          -include $GITHUB_WORKSPACE/entservices-testframework/Tests/mocks/pkg.h
+          -include $GITHUB_WORKSPACE/entservices-testframework/Tests/mocks/secure_wrappermock.h
+          -include $GITHUB_WORKSPACE/entservices-testframework/Tests/mocks/wpa_ctrl_mock.h
+          -include $GITHUB_WORKSPACE/entservices-testframework/Tests/mocks/readprocMockInterface.h
+          -include $GITHUB_WORKSPACE/entservices-testframework/Tests/mocks/gdialservice.h
+          -include $GITHUB_WORKSPACE/entservices-testframework/Tests/mocks/MotionDetection.h
+          -include $GITHUB_WORKSPACE/entservices-testframework/Tests/mocks/dsFPD.h
+          --coverage
+          -Wall -Wno-unused-result -Wno-deprecated-declarations -Wno-error=format=
+          -DUSE_IARMBUS
+          -DENABLE_SYSTEM_GET_STORE_DEMO_LINK
+          -DENABLE_DEEP_SLEEP
+          -DENABLE_SET_WAKEUP_SRC_CONFIG
+          -DENABLE_THERMAL_PROTECTION
+          -DUSE_DRM_SCREENCAPTURE
+          -DHAS_API_SYSTEM
+          -DHAS_API_POWERSTATE
+          -DHAS_RBUS
+          -DCLOCK_BRIGHTNESS_ENABLED
+          -DUSE_DS
+          -DENABLE_DEVICE_MANUFACTURER_INFO"
+          -DCOMCAST_CONFIG=OFF
+          -DCMAKE_DISABLE_FIND_PACKAGE_DS=ON
+          -DCMAKE_DISABLE_FIND_PACKAGE_IARMBus=ON
+          -DCMAKE_DISABLE_FIND_PACKAGE_Udev=ON
+          -DCMAKE_DISABLE_FIND_PACKAGE_RFC=ON
+          -DCMAKE_DISABLE_FIND_PACKAGE_RBus=ON
+          -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+          -DDS_FOUND=ON
+          -DHAS_FRONT_PANEL=ON
+          -DPLUGIN_LEDCONTROL=ON
+          -DPLUGIN_FRONTPANEL=ON
+          -DPLUGIN_MOTION_DETECTION=ON
+          -DRDK_SERVICE_L2_TEST=ON
+          -DPLUGIN_L2Tests=ON
+          -DUSE_THUNDER_R4=ON
+          -DHIDE_NON_EXTERNAL_SYMBOLS=OFF
+          &&
+          cmake --build build/entservices-peripherals -j8
+          &&
+          cmake --install build/entservices-peripherals
+
+      - name: Build entservices-testframework
+        run: >
+          cmake -G Ninja
+          -S "$GITHUB_WORKSPACE/entservices-testframework"
+          -B build/entservices-testframework
+          -DCMAKE_TOOLCHAIN_FILE="${{ env.TOOLCHAIN_FILE }}"
+          -DCMAKE_INSTALL_PREFIX="$GITHUB_WORKSPACE/install/usr"
+          -DCMAKE_MODULE_PATH="$GITHUB_WORKSPACE/install/tools/cmake"
+          -DHIDE_NON_EXTERNAL_SYMBOLS=OFF
+          -DCMAKE_CXX_FLAGS="
+          -fprofile-arcs
+          -ftest-coverage
+          -DEXCEPTIONS_ENABLE=ON
+          -DUSE_THUNDER_R4=ON
+          -DTHUNDER_VERSION=4
+          -DTHUNDER_VERSION_MAJOR=4
+          -DTHUNDER_VERSION_MINOR=4
+          -DRDK_SERVICE_L2_TEST
+          -I $GITHUB_WORKSPACE/entservices-testframework/Tests/headers
+          -I $GITHUB_WORKSPACE/entservices-testframework/Tests/headers/audiocapturemgr
+          -I $GITHUB_WORKSPACE/entservices-testframework/Tests/headers/rdk/ds
+          -I $GITHUB_WORKSPACE/entservices-testframework/Tests/headers/rdk/iarmbus
+          -I $GITHUB_WORKSPACE/entservices-testframework/Tests/headers/rdk/iarmmgrs-hal
+          -I $GITHUB_WORKSPACE/entservices-testframework/Tests/headers/ccec/drivers
+          -I $GITHUB_WORKSPACE/entservices-testframework/Tests/headers/network
+          -I $GITHUB_WORKSPACE/entservices-peripherals/helpers
+          -I $GITHUB_WORKSPACE/entservices-testframework/Tests
+          -I $GITHUB_WORKSPACE/Thunder/Source
+          -I $GITHUB_WORKSPACE/Thunder/Source/core
+          -I $GITHUB_WORKSPACE/install/usr/include
+          -I $GITHUB_WORKSPACE/install/usr/include/WPEFramework
+          -include $GITHUB_WORKSPACE/entservices-testframework/Tests/mocks/devicesettings.h
+          -include $GITHUB_WORKSPACE/entservices-testframework/Tests/mocks/Iarm.h
+          -include $GITHUB_WORKSPACE/entservices-testframework/Tests/mocks/Rfc.h
+          -include $GITHUB_WORKSPACE/entservices-testframework/Tests/mocks/RBus.h
+          -include $GITHUB_WORKSPACE/entservices-testframework/Tests/mocks/Telemetry.h
+          -include $GITHUB_WORKSPACE/entservices-testframework/Tests/mocks/Udev.h
+          -include $GITHUB_WORKSPACE/entservices-testframework/Tests/mocks/maintenanceMGR.h
+          -include $GITHUB_WORKSPACE/entservices-testframework/Tests/mocks/pkg.h
+          -include $GITHUB_WORKSPACE/entservices-testframework/Tests/mocks/secure_wrappermock.h
+          -include $GITHUB_WORKSPACE/entservices-testframework/Tests/mocks/wpa_ctrl_mock.h
+          -include $GITHUB_WORKSPACE/entservices-testframework/Tests/mocks/readprocMockInterface.h
+          -include $GITHUB_WORKSPACE/entservices-testframework/Tests/mocks/gdialservice.h
+          -include $GITHUB_WORKSPACE/entservices-testframework/Tests/mocks/dsFPD.h
+          --coverage
+          -Wall -Wno-unused-result -Wno-deprecated-declarations -Wno-error=format=
+          -Wl,-wrap,system -Wl,-wrap,syslog -Wl,--no-as-needed
+          -DENABLE_TELEMETRY_LOGGING
+          -DUSE_IARMBUS
+          -DENABLE_SYSTEM_GET_STORE_DEMO_LINK
+          -DENABLE_DEEP_SLEEP
+          -DENABLE_SET_WAKEUP_SRC_CONFIG
+          -DENABLE_THERMAL_PROTECTION
+          -DUSE_DRM_SCREENCAPTURE
+          -DHAS_API_SYSTEM
+          -DHAS_API_POWERSTATE
+          -DHAS_RBUS
+          -DCLOCK_BRIGHTNESS_ENABLED
+          -DUSE_DS
+          -DENABLE_DEVICE_MANUFACTURER_INFO"
+          -DCOMCAST_CONFIG=OFF
+          -DCMAKE_DISABLE_FIND_PACKAGE_DS=ON
+          -DCMAKE_DISABLE_FIND_PACKAGE_IARMBus=ON
+          -DCMAKE_DISABLE_FIND_PACKAGE_Udev=ON
+          -DCMAKE_DISABLE_FIND_PACKAGE_RFC=ON
+          -DCMAKE_DISABLE_FIND_PACKAGE_RBus=ON
+          -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+          -DDS_FOUND=ON
+          -DHAS_FRONT_PANEL=ON
+          -DPLUGIN_LEDCONTROL=ON
+          -DPLUGIN_FRONTPANEL=ON
+          -DPLUGIN_MOTION_DETECTION=ON
+          -DRDK_SERVICE_L2_TEST=ON
+          -DPLUGIN_L2Tests=ON
+          -DUSE_THUNDER_R4=ON
+          -DHIDE_NON_EXTERNAL_SYMBOLS=OFF
+          &&
+          cmake --build build/entservices-testframework -j8
+          &&
+          cmake --install build/entservices-testframework
+
+      - name: Set up files
+        run: >
+          sudo mkdir -p -m 777
+          /tmp/test/testApp/etc/apps
+          /opt/persistent
+          /opt/secure
+          /opt/secure/reboot
+          /opt/secure/persistent
+          /opt/secure/persistent/System
+          /opt/logs
+          /lib/rdk
+          /run/media/sda1/logs/PreviousLogs
+          /run/sda1/UsbTestFWUpdate
+          /run/sda1/UsbProdFWUpdate
+          /run/sda2
+          /var/run/wpa_supplicant
+          /tmp/bus/usb/devices/100-123
+          /tmp/bus/usb/devices/101-124
+          /tmp/block/sda/device
+          /tmp/block/sdb/device
+          /dev/disk/by-id
+          /dev
+          &&
+          if [ ! -f mknod /dev/sda c 240 0 ]; then mknod /dev/sda c 240 0; fi &&
+          if [ ! -f mknod /dev/sda1 c 240 0 ]; then mknod /dev/sda1 c 240 0; fi &&
+          if [ ! -f mknod /dev/sda2 c 240 0 ]; then mknod /dev/sda2 c 240 0; fi &&
+          if [ ! -f mknod /dev/sdb c 240 0 ]; then mknod /dev/sdb c 240 0; fi &&
+          if [ ! -f mknod /dev/sdb1 c 240 0 ]; then mknod /dev/sdb1 c 240 0; fi &&
+          if [ ! -f mknod /dev/sdb2 c 240 0 ]; then mknod /dev/sdb2 c 240 0; fi
+          &&
+          sudo touch
+          /tmp/test/testApp/etc/apps/testApp_package.json
+          /opt/rdk_maintenance.conf
+          /opt/persistent/timeZoneDST
+          /opt/standbyReason.txt
+          /opt/tmtryoptout
+          /opt/fwdnldstatus.txt
+          /opt/dcm.properties
+          /etc/device.properties
+          /etc/dcm.properties
+          /etc/authService.conf
+          /version.txt
+          /run/media/sda1/logs/PreviousLogs/logFile.txt
+          /run/sda1/HSTP11MWR_5.11p5s1_VBN_sdy.bin
+          /run/sda1/UsbTestFWUpdate/HSTP11MWR_3.11p5s1_VBN_sdy.bin
+          /run/sda1/UsbProdFWUpdate/HSTP11MWR_4.11p5s1_VBN_sdy.bin
+          /lib/rdk/getMaintenanceStartTime.sh
+          /tmp/opkg.conf
+          /tmp/bus/usb/devices/100-123/serial
+          /tmp/bus/usb/devices/101-124/serial
+          /tmp/block/sda/device/vendor
+          /tmp/block/sda/device/model
+          /tmp/block/sdb/device/vendor
+          /tmp/block/sdb/device/model
+          &&
+          sudo chmod -R 777
+          /opt/rdk_maintenance.conf
+          /opt/persistent/timeZoneDST
+          /opt/standbyReason.txt
+          /opt/tmtryoptout
+          /opt/fwdnldstatus.txt
+          /opt/dcm.properties
+          /etc/device.properties
+          /etc/dcm.properties
+          /etc/authService.conf
+          /version.txt
+          /lib/rdk/getMaintenanceStartTime.sh
+          /tmp/opkg.conf
+          /tmp/bus/usb/devices/100-123/serial
+          /tmp/block/sda/device/vendor
+          /tmp/block/sda/device/model
+          /tmp/bus/usb/devices/101-124/serial
+          /tmp/block/sdb/device/vendor
+          /tmp/block/sdb/device/model
+          &&
+          cd /dev/disk/by-id/
+          &&
+          sudo ln -s ../../sda /dev/disk/by-id/usb-Generic_Flash_Disk_B32FD507-0
+          &&
+          sudo ln -s ../../sdb /dev/disk/by-id/usb-JetFlash_Transcend_16GB_UEUIRCXT-0
+          &&
+          ls -l /dev/disk/by-id/usb-Generic_Flash_Disk_B32FD507-0
+          &&
+          ls -l /dev/disk/by-id/usb-JetFlash_Transcend_16GB_UEUIRCXT-0
+
+      - name: Download pact_verifier_cli
+        run: |
+          export PATH="$GITHUB_WORKSPACE/install/usr/bin:${PATH}"
+          $GITHUB_WORKSPACE/entservices-testframework/Tests/L2Tests/pact/install-verifier-cli.sh
+
+      - name: Run unit tests without valgrind
+        run: >
+          PATH=$GITHUB_WORKSPACE/install/usr/bin:${PATH}
+          LD_LIBRARY_PATH=$GITHUB_WORKSPACE/install/usr/lib:$GITHUB_WORKSPACE/install/usr/lib/wpeframework/plugins:${LD_LIBRARY_PATH}
+          GTEST_OUTPUT="json:$(pwd)/rdkL2TestResults.json"
+          RdkServicesL2Test &&
+          cp -rf $(pwd)/rdkL2TestResults.json $GITHUB_WORKSPACE/rdkL2TestResultsWithoutValgrind.json &&
+          rm -rf $(pwd)/rdkL2TestResults.json
+
+      - name: Run unit tests with valgrind
+        if: ${{ !env.ACT }}
+        run: >
+          PATH=$GITHUB_WORKSPACE/install/usr/bin:${PATH}
+          LD_LIBRARY_PATH=$GITHUB_WORKSPACE/install/usr/lib:$GITHUB_WORKSPACE/install/usr/lib/wpeframework/plugins:${LD_LIBRARY_PATH}
+          GTEST_OUTPUT="json:$(pwd)/rdkL2TestResults.json"
+          valgrind
+          --tool=memcheck
+          --log-file=valgrind_log
+          --leak-check=yes
+          --show-reachable=yes
+          --track-fds=yes
+          --fair-sched=try
+          RdkServicesL2Test &&
+          cp -rf $(pwd)/rdkL2TestResults.json $GITHUB_WORKSPACE/rdkL2TestResultsWithValgrind.json &&
+          rm -rf $(pwd)/rdkL2TestResults.json
+
+      - name: Generate coverage
+        if: ${{ matrix.coverage == 'with-coverage' && !env.ACT }}
+        run: >
+          cp $GITHUB_WORKSPACE/entservices-testframework/Tests/L2Tests/.lcovrc_l2 ~/.lcovrc
+          &&
+          lcov -c
+          -o coverage.info
+          -d build/entservices-peripherals
+          &&
+          lcov
+          -r coverage.info
+          '/usr/include/*'
+          '*/build/entservices-entservices-testframework/_deps/*'
+          '*/build/entservices-peripherals/_deps/*'
+          '*/install/usr/include/*'
+          '*/Tests/headers/*'
+          '*/Tests/mocks/*'
+          '*/Tests/L2Tests/tests/*'
+          '*/Tests/L2Tests/*'
+          '*/googlemock/*'
+          '*/googletest/*'
+          '*/sqlite/*'
+          -o filtered_coverage.info
+          &&
+          genhtml
+          -o coverage
+          -t "entservices-peripherals coverage"
+          filtered_coverage.info
+
+      - name: Upload artifacts
+        if: ${{ !env.ACT }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: artifacts
+          path: |
+            coverage/
+            valgrind_log
+            rdkL2TestResultsWithoutValgrind.json
+            rdkL2TestResultsWithValgrind.json
+          if-no-files-found: warn
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,10 @@ if(RDK_SERVICES_L1_TEST)
     add_subdirectory(Tests/L1Tests)
 endif()
 
+if(RDK_SERVICE_L2_TEST)
+    add_subdirectory(Tests/L2Tests)
+endif()
+
 if(PLUGIN_VOICECONTROL)
     add_subdirectory(VoiceControl)
 endif()

--- a/LEDControl/CMakeLists.txt
+++ b/LEDControl/CMakeLists.txt
@@ -55,6 +55,16 @@ set_target_properties(${PLUGIN_IMPLEMENTATION} PROPERTIES
         CXX_STANDARD 11
         CXX_STANDARD_REQUIRED YES)
 
+if (RDK_SERVICE_L2_TEST)
+   find_library(TESTMOCKLIB_LIBRARIES NAMES TestMocklib)
+   if (TESTMOCKLIB_LIBRARIES)
+       message ("linking mock libraries ${TESTMOCKLIB_LIBRARIES} library")
+       target_link_libraries(${PLUGIN_IMPLEMENTATION} PRIVATE ${TESTMOCKLIB_LIBRARIES})
+   else (TESTMOCKLIB_LIBRARIES)
+       message ("Require ${TESTMOCKLIB_LIBRARIES} library")
+   endif (TESTMOCKLIB_LIBRARIES)
+endif (RDK_SERVICES_L2_TEST)
+
 target_compile_definitions(${PLUGIN_IMPLEMENTATION} PRIVATE MODULE_NAME=Plugin_${PLUGIN_NAME})
 
 find_package(DS)

--- a/MotionDetection/CMakeLists.txt
+++ b/MotionDetection/CMakeLists.txt
@@ -33,7 +33,7 @@ set_target_properties(${MODULE_NAME} PROPERTIES
 target_include_directories(${MODULE_NAME} PRIVATE ../helpers)
 set_source_files_properties(MotionDetection.cpp PROPERTIES COMPILE_FLAGS "-fexceptions")
 
-if (NOT RDK_SERVICES_L1_TEST)
+if (NOT RDK_SERVICES_L1_TEST AND NOT RDK_SERVICE_L2_TEST)
 target_link_libraries(${MODULE_NAME} PRIVATE ${NAMESPACE}Plugins::${NAMESPACE}Plugins md-hal)
 else(RDK_SERVICES_L1_TEST)
         target_link_libraries(${MODULE_NAME} PRIVATE ${NAMESPACE}Plugins::${NAMESPACE}Plugins)

--- a/Tests/L2Tests/CMakeLists.txt
+++ b/Tests/L2Tests/CMakeLists.txt
@@ -1,0 +1,73 @@
+# If not stated otherwise in this file or this component's LICENSE file the
+# following copyright and licenses apply:
+#
+# Copyright 2023 RDK Management
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+set(PLUGIN_NAME L2TestsPE)
+set(MODULE_NAME ${NAMESPACE}${PLUGIN_NAME})
+set(THUNDER_PORT 9998)
+find_package(${NAMESPACE}Plugins REQUIRED)
+
+if(PLUGIN_LEDCONTROL)
+    set(SRC_FILES ${SRC_FILES} tests/LedControl_L2Test.cpp)
+endif()
+
+add_library(${MODULE_NAME} SHARED ${SRC_FILES})
+
+set_target_properties(${MODULE_NAME} PROPERTIES
+        CXX_STANDARD 14
+        CXX_STANDARD_REQUIRED YES)
+
+target_compile_definitions(${MODULE_NAME}
+            PRIVATE
+            MODULE_NAME=Plugin_${PLUGIN_NAME}
+            THUNDER_PORT="${THUNDER_PORT}")
+
+target_compile_options(${MODULE_NAME} PRIVATE -Wno-error)
+target_link_libraries(${MODULE_NAME} PRIVATE ${NAMESPACE}Plugins::${NAMESPACE}Plugins)
+
+if (NOT L2_TEST_OOP_RPC)
+    find_library(TESTMOCKLIB_LIBRARIES NAMES TestMocklib)
+    if (TESTMOCKLIB_LIBRARIES)
+        message ("Found mock library - ${TESTMOCKLIB_LIBRARIES}")
+        target_link_libraries(${MODULE_NAME} PRIVATE ${TESTMOCKLIB_LIBRARIES})
+    else (TESTMOCKLIB_LIBRARIES)
+         message ("Require ${TESTMOCKLIB_LIBRARIES} library")
+    endif (TESTMOCKLIB_LIBRARIES)
+endif (NOT L2_TEST_OOP_RPC)
+
+find_library(MOCKACCESSOR_LIBRARIES NAMES MockAccessor)
+if (MOCKACCESSOR_LIBRARIES)
+    message ("Found MockAccessor library - ${MOCKACCESSOR_LIBRARIES}")
+    target_link_libraries(${MODULE_NAME} PRIVATE ${MOCKACCESSOR_LIBRARIES})
+else (MOCKACCESSOR_LIBRARIES)
+     message ("Require ${MOCKACCESSOR_LIBRARIES} library")
+endif (MOCKACCESSOR_LIBRARIES)
+
+target_include_directories(
+    ${MODULE_NAME} PRIVATE ./
+    ../../helpers
+    ../../../entservices-testframework/Tests/mocks
+    ../../../entservices-testframework/Tests/mocks/thunder
+    ../../../entservices-testframework/Tests/mocks/devicesettings
+    ../../../entservices-testframework/Tests/mocks/MockPlugin
+    ../../../entservices-testframework/Tests/L2Tests/L2TestsPlugin
+    ${CMAKE_INSTALL_PREFIX}/include
+    )
+
+install(TARGETS ${MODULE_NAME} DESTINATION lib)
+
+write_config(${PLUGIN_NAME})

--- a/Tests/L2Tests/tests/LedControl_L2Test.cpp
+++ b/Tests/L2Tests/tests/LedControl_L2Test.cpp
@@ -1,0 +1,910 @@
+#include "L2Tests.h"
+#include "L2TestsMock.h"
+#include <condition_variable>
+#include <fstream>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <interfaces/ILEDControl.h>
+#include <mutex>
+
+#define TEST_LOG(x, ...)                                                                                                                         \
+    fprintf(stderr, "\033[1;32m[%s:%d](%s)<PID:%d><TID:%d>" x "\n\033[0m", __FILE__, __LINE__, __FUNCTION__, getpid(), gettid(), ##__VA_ARGS__); \
+    fflush(stderr);
+
+#define LED_CALLSIGN _T("org.rdk.LEDControl.1")
+#define LEDL2TEST_CALLSIGN _T("L2tests.1")
+
+using ::testing::NiceMock;
+using namespace WPEFramework;
+using testing::StrictMock;
+using ::WPEFramework::Exchange::ILEDControl;
+
+class LEDControl_L2test : public L2TestMocks {
+protected:
+    virtual ~LEDControl_L2test() override;
+
+public:
+    LEDControl_L2test();
+    uint32_t CreateDeviceLEDControlInterfaceObject();
+
+protected:
+    /** @brief Pointer to the IShell interface */
+    PluginHost::IShell* m_controller_LED;
+
+    /** @brief Pointer to the ILEDControl interface */
+    Exchange::ILEDControl* m_LEDplugin;
+};
+
+LEDControl_L2test::LEDControl_L2test()
+    : L2TestMocks()
+{
+    uint32_t status = Core::ERROR_GENERAL;
+
+    ON_CALL(*p_dsFPDMock, dsFPInit())
+        .WillByDefault(testing::Return(dsERR_NONE));
+
+    /* Activate plugin in constructor */
+    status = ActivateService("org.rdk.LEDControl");
+    EXPECT_EQ(Core::ERROR_NONE, status);
+
+    if (CreateDeviceLEDControlInterfaceObject() != Core::ERROR_NONE) {
+        TEST_LOG("Invalid LEDControl_Client");
+    } else {
+        EXPECT_TRUE(m_controller_LED != nullptr);
+        if (m_controller_LED) {
+            EXPECT_TRUE(m_LEDplugin != nullptr);
+            if (m_LEDplugin) {
+                m_LEDplugin->AddRef();
+            } else {
+                TEST_LOG("m_LEDplugin is NULL");
+            }
+        } else {
+            TEST_LOG("m_controller_LED is NULL");
+        }
+    }
+}
+
+LEDControl_L2test::~LEDControl_L2test()
+{
+    TEST_LOG("Inside LEDControl_L2test destructor");
+
+    ON_CALL(*p_dsFPDMock, dsFPTerm())
+        .WillByDefault(testing::Return(dsERR_NONE));
+
+    if (m_LEDplugin) {
+        m_LEDplugin->Release();
+        m_LEDplugin = nullptr;
+    }
+    if (m_controller_LED) {
+        m_controller_LED->Release();
+        m_controller_LED = nullptr;
+    }
+
+    uint32_t status = Core::ERROR_GENERAL;
+
+    /* Deactivate plugin in destructor */
+    status = DeactivateService("org.rdk.LEDControl");
+    EXPECT_EQ(Core::ERROR_NONE, status);
+}
+
+uint32_t LEDControl_L2test::CreateDeviceLEDControlInterfaceObject()
+{
+    uint32_t return_value = Core::ERROR_GENERAL;
+    Core::ProxyType<RPC::InvokeServerType<1, 0, 4>> LEDControl_Engine;
+    Core::ProxyType<RPC::CommunicatorClient> LEDControl_Client;
+
+    TEST_LOG("Creating LEDControl_Engine");
+    LEDControl_Engine = Core::ProxyType<RPC::InvokeServerType<1, 0, 4>>::Create();
+    LEDControl_Client = Core::ProxyType<RPC::CommunicatorClient>::Create(Core::NodeId("/tmp/communicator"), Core::ProxyType<Core::IIPCServer>(LEDControl_Engine));
+
+    TEST_LOG("Creating LEDControl_Engine Announcements");
+#if ((THUNDER_VERSION == 2) || ((THUNDER_VERSION == 4) && (THUNDER_VERSION_MINOR == 2)))
+    LEDControl_Engine->Announcements(mLEDControl_Client->Announcement());
+#endif
+    if (!LEDControl_Client.IsValid()) {
+        TEST_LOG("Invalid LEDControl_Client");
+    } else {
+        m_controller_LED = LEDControl_Client->Open<PluginHost::IShell>(_T("org.rdk.LEDControl"), ~0, 3000);
+        if (m_controller_LED) {
+            m_LEDplugin = m_controller_LED->QueryInterface<Exchange::ILEDControl>();
+            return_value = Core::ERROR_NONE;
+        }
+    }
+    return return_value;
+}
+
+/************Test case Details **************************
+** 1.getSupportedLEDStates with states set as "ACTIVE,STANDBY" using jsonrpc
+*******************************************************/
+
+TEST_F(LEDControl_L2test, JSONRPC_GetSupportedLEDStates_ACTIVE)
+{
+    JSONRPC::LinkType<Core::JSON::IElement> jsonrpc(LED_CALLSIGN, LEDL2TEST_CALLSIGN);
+    uint32_t status = Core::ERROR_GENERAL;
+    JsonObject param, result;
+
+    //mock dsFPGetSupportedLEDStates to respond with ACTIVE and STANDBY states
+    EXPECT_CALL(*p_dsFPDMock, dsFPGetSupportedLEDStates(::testing::_))
+        .WillOnce(::testing::DoAll(
+            ::testing::SetArgPointee<0>(1 << dsFPD_LED_DEVICE_ACTIVE | 1 << dsFPD_LED_DEVICE_STANDBY),
+            ::testing::Return(dsERR_NONE)));
+
+    status = InvokeServiceMethod("org.rdk.LEDControl.1", "getSupportedLEDStates", param, result);
+    EXPECT_EQ(Core::ERROR_NONE, status);
+    EXPECT_TRUE(result["success"].Boolean());
+}
+
+/************Test case Details **************************
+** 1.setLEDState with states set as "ACTIVE" using jsonrpc
+*******************************************************/
+
+TEST_F(LEDControl_L2test, JSONRPC_Set_LEDState_ACTIVE)
+{
+    JSONRPC::LinkType<Core::JSON::IElement> jsonrpc(LED_CALLSIGN, LEDL2TEST_CALLSIGN);
+    uint32_t status = Core::ERROR_GENERAL;
+    JsonObject param, response;
+
+    EXPECT_CALL(*p_dsFPDMock, dsFPSetLEDState(::testing::_))
+        .WillOnce(::testing::Return(dsERR_NONE));
+
+    param["state"] = "ACTIVE";
+    status = InvokeServiceMethod("org.rdk.LEDControl.1", "setLEDState", param, response);
+    EXPECT_EQ(status, Core::ERROR_NONE);
+}
+
+/************Test case Details **************************
+** 1.getLEDState with states set as "ACTIVE" using jsonrpc
+*******************************************************/
+
+TEST_F(LEDControl_L2test, JSONRPC_Get_LEDState_ACTIVE)
+{
+    JSONRPC::LinkType<Core::JSON::IElement> jsonrpc(LED_CALLSIGN, LEDL2TEST_CALLSIGN);
+    uint32_t status = Core::ERROR_GENERAL;
+    JsonObject param, result;
+
+    EXPECT_CALL(*p_dsFPDMock, dsFPGetLEDState(::testing::_))
+        .WillOnce(::testing::DoAll(
+            ::testing::SetArgPointee<0>(dsFPD_LED_DEVICE_ACTIVE),
+            ::testing::Return(dsERR_NONE)));
+
+    status = InvokeServiceMethod("org.rdk.LEDControl.1", "getLEDState", param, result);
+    EXPECT_EQ(status, Core::ERROR_NONE);
+}
+
+/************Test case Details **************************
+** 1.GetSupportedLEDStates with states set as "ACTIVE" using comrpc
+*******************************************************/
+
+TEST_F(LEDControl_L2test, GetSupportedLEDStates_ACTIVE)
+{
+    uint32_t status = Core::ERROR_NONE;
+    bool success = false;
+    WPEFramework::RPC::IStringIterator* supportedLEDStates;
+
+    EXPECT_CALL(*p_dsFPDMock, dsFPGetSupportedLEDStates(::testing::_))
+        .WillOnce(::testing::DoAll(
+            ::testing::SetArgPointee<0>(1 << dsFPD_LED_DEVICE_ACTIVE),
+            ::testing::Return(dsERR_NONE)));
+
+    status = m_LEDplugin->GetSupportedLEDStates(supportedLEDStates, success);
+    EXPECT_EQ(status, Core::ERROR_NONE);
+    EXPECT_TRUE(success);
+
+    if (supportedLEDStates != nullptr) {
+        string value;
+        while (supportedLEDStates->Next(value) == true) {
+            TEST_LOG("supportedLEDState: %s", value.c_str());
+        }
+    } else {
+        TEST_LOG("supportedLEDStates is empty!");
+    }
+}
+
+/************Test case Details **************************
+** 1.GetSupportedLEDStates with states set as "STANDBY" using comrpc
+*******************************************************/
+
+TEST_F(LEDControl_L2test, GetSupportedLEDStates_STANDBY)
+{
+    uint32_t status = Core::ERROR_NONE;
+    bool success = false;
+    WPEFramework::RPC::IStringIterator* supportedLEDStates;
+
+    EXPECT_CALL(*p_dsFPDMock, dsFPGetSupportedLEDStates(::testing::_))
+        .WillOnce(::testing::DoAll(
+            ::testing::SetArgPointee<0>(1 << dsFPD_LED_DEVICE_STANDBY),
+            ::testing::Return(dsERR_NONE)));
+
+    status = m_LEDplugin->GetSupportedLEDStates(supportedLEDStates, success);
+    EXPECT_EQ(status, Core::ERROR_NONE);
+    EXPECT_TRUE(success);
+
+    if (supportedLEDStates != nullptr) {
+        string value;
+        while (supportedLEDStates->Next(value) == true) {
+            TEST_LOG("supportedLEDState: %s", value.c_str());
+        }
+    } else {
+        TEST_LOG("supportedLEDStates is empty!");
+    }
+}
+
+/************Test case Details **************************
+** 1.GetSupportedLEDStates with states set as "WPSCONNECTING" using comrpc
+*******************************************************/
+
+TEST_F(LEDControl_L2test, GetSupportedLEDStates_WPSCONNECTING)
+{
+    uint32_t status = Core::ERROR_NONE;
+    bool success = false;
+    WPEFramework::RPC::IStringIterator* supportedLEDStates;
+
+    EXPECT_CALL(*p_dsFPDMock, dsFPGetSupportedLEDStates(::testing::_))
+        .WillOnce(::testing::DoAll(
+            ::testing::SetArgPointee<0>(1 << dsFPD_LED_DEVICE_WPS_CONNECTING),
+            ::testing::Return(dsERR_NONE)));
+
+    status = m_LEDplugin->GetSupportedLEDStates(supportedLEDStates, success);
+    EXPECT_EQ(status, Core::ERROR_NONE);
+    EXPECT_TRUE(success);
+
+    if (supportedLEDStates != nullptr) {
+        string value;
+        while (supportedLEDStates->Next(value) == true) {
+            TEST_LOG("supportedLEDState: %s", value.c_str());
+        }
+    } else {
+        TEST_LOG("supportedLEDStates is empty!");
+    }
+}
+
+/************Test case Details **************************
+** 1.GetSupportedLEDStates with states set as "WPSCONNECTED" using comrpc
+*******************************************************/
+
+TEST_F(LEDControl_L2test, GetSupportedLEDStates_WPSCONNECTED)
+{
+    uint32_t status = Core::ERROR_NONE;
+    bool success = false;
+    WPEFramework::RPC::IStringIterator* supportedLEDStates;
+
+    EXPECT_CALL(*p_dsFPDMock, dsFPGetSupportedLEDStates(::testing::_))
+        .WillOnce(::testing::DoAll(
+            ::testing::SetArgPointee<0>(1 << dsFPD_LED_DEVICE_WPS_CONNECTED),
+            ::testing::Return(dsERR_NONE)));
+
+    status = m_LEDplugin->GetSupportedLEDStates(supportedLEDStates, success);
+    EXPECT_EQ(status, Core::ERROR_NONE);
+    EXPECT_TRUE(success);
+
+    if (supportedLEDStates != nullptr) {
+        string value;
+        while (supportedLEDStates->Next(value) == true) {
+            TEST_LOG("supportedLEDState: %s", value.c_str());
+        }
+    } else {
+        TEST_LOG("supportedLEDStates is empty!");
+    }
+}
+
+/************Test case Details **************************
+** 1.GetSupportedLEDStates with states set as "WPSERROR" using comrpc
+*******************************************************/
+
+TEST_F(LEDControl_L2test, GetSupportedLEDStates_WPSERROR)
+{
+    uint32_t status = Core::ERROR_NONE;
+    bool success = false;
+    WPEFramework::RPC::IStringIterator* supportedLEDStates;
+
+    EXPECT_CALL(*p_dsFPDMock, dsFPGetSupportedLEDStates(::testing::_))
+        .WillOnce(::testing::DoAll(
+            ::testing::SetArgPointee<0>(1 << dsFPD_LED_DEVICE_WPS_ERROR),
+            ::testing::Return(dsERR_NONE)));
+
+    status = m_LEDplugin->GetSupportedLEDStates(supportedLEDStates, success);
+    EXPECT_EQ(status, Core::ERROR_NONE);
+    EXPECT_TRUE(success);
+
+    if (supportedLEDStates != nullptr) {
+        string value;
+        while (supportedLEDStates->Next(value) == true) {
+            TEST_LOG("supportedLEDState: %s", value.c_str());
+        }
+    } else {
+        TEST_LOG("supportedLEDStates is empty!");
+    }
+}
+
+/************Test case Details **************************
+** 1.GetSupportedLEDStates with states set as "FACTORY_RESET" using comrpc
+*******************************************************/
+
+TEST_F(LEDControl_L2test, GetSupportedLEDStates_RESET)
+{
+    uint32_t status = Core::ERROR_NONE;
+    bool success = false;
+    WPEFramework::RPC::IStringIterator* supportedLEDStates;
+
+    EXPECT_CALL(*p_dsFPDMock, dsFPGetSupportedLEDStates(::testing::_))
+        .WillOnce(::testing::DoAll(
+            ::testing::SetArgPointee<0>(1 << dsFPD_LED_DEVICE_FACTORY_RESET),
+            ::testing::Return(dsERR_NONE)));
+
+    status = m_LEDplugin->GetSupportedLEDStates(supportedLEDStates, success);
+    EXPECT_EQ(status, Core::ERROR_NONE);
+    EXPECT_TRUE(success);
+
+    if (supportedLEDStates != nullptr) {
+        string value;
+        while (supportedLEDStates->Next(value) == true) {
+            TEST_LOG("supportedLEDState: %s", value.c_str());
+        }
+    } else {
+        TEST_LOG("supportedLEDStates is empty!");
+    }
+}
+
+/************Test case Details **************************
+** 1.GetSupportedLEDStates with states set as "USB_UPGRADE" using comrpc
+*******************************************************/
+
+TEST_F(LEDControl_L2test, GetSupportedLEDStates_USBUPGRADE)
+{
+    uint32_t status = Core::ERROR_NONE;
+    bool success = false;
+    WPEFramework::RPC::IStringIterator* supportedLEDStates;
+
+    EXPECT_CALL(*p_dsFPDMock, dsFPGetSupportedLEDStates(::testing::_))
+        .WillOnce(::testing::DoAll(
+            ::testing::SetArgPointee<0>(1 << dsFPD_LED_DEVICE_USB_UPGRADE),
+            ::testing::Return(dsERR_NONE)));
+
+    status = m_LEDplugin->GetSupportedLEDStates(supportedLEDStates, success);
+    EXPECT_EQ(status, Core::ERROR_NONE);
+    EXPECT_TRUE(success);
+
+    if (supportedLEDStates != nullptr) {
+        string value;
+        while (supportedLEDStates->Next(value) == true) {
+            TEST_LOG("supportedLEDState: %s", value.c_str());
+        }
+    } else {
+        TEST_LOG("supportedLEDStates is empty!");
+    }
+}
+
+/************Test case Details **************************
+** 1.GetSupportedLEDStates with states set as "SOFTWARE_DOWNLOAD_ERROR" using comrpc
+*******************************************************/
+
+TEST_F(LEDControl_L2test, GetSupportedLEDStates_DOWNLOADERROR)
+{
+    uint32_t status = Core::ERROR_NONE;
+    bool success = false;
+    WPEFramework::RPC::IStringIterator* supportedLEDStates;
+
+    EXPECT_CALL(*p_dsFPDMock, dsFPGetSupportedLEDStates(::testing::_))
+        .WillOnce(::testing::DoAll(
+            ::testing::SetArgPointee<0>(1 << dsFPD_LED_DEVICE_SOFTWARE_DOWNLOAD_ERROR),
+            ::testing::Return(dsERR_NONE)));
+
+    status = m_LEDplugin->GetSupportedLEDStates(supportedLEDStates, success);
+    EXPECT_EQ(status, Core::ERROR_NONE);
+    EXPECT_TRUE(success);
+
+    if (supportedLEDStates != nullptr) {
+        string value;
+        while (supportedLEDStates->Next(value) == true) {
+            TEST_LOG("supportedLEDState: %s", value.c_str());
+        }
+    } else {
+        TEST_LOG("supportedLEDStates is empty!");
+    }
+}
+
+/************Test case Details **************************
+** 1.GetSupportedLEDStates with mock returning error using comrpc
+*******************************************************/
+
+TEST_F(LEDControl_L2test, GetSupportedLEDStates_ErrorCase)
+{
+    uint32_t status = Core::ERROR_NONE;
+    bool success = false;
+    WPEFramework::RPC::IStringIterator* supportedLEDStates;
+
+    //return dsERR_GENERAL for failure case
+    EXPECT_CALL(*p_dsFPDMock, dsFPGetSupportedLEDStates(::testing::_))
+        .WillOnce(::testing::Return(dsERR_GENERAL));
+
+    status = m_LEDplugin->GetSupportedLEDStates(supportedLEDStates, success);
+    EXPECT_EQ(status, Core::ERROR_GENERAL);
+    EXPECT_FALSE(success);
+}
+
+/************Test case Details **************************
+** 1.SetLEDState with state set to be "ACTIVE" using comrpc
+*******************************************************/
+
+TEST_F(LEDControl_L2test, Set_LEDState_ACTIVE)
+{
+    uint32_t status = Core::ERROR_NONE;
+    string State = "ACTIVE";
+    bool success = false;
+
+    EXPECT_CALL(*p_dsFPDMock, dsFPSetLEDState(::testing::_))
+        .WillOnce(::testing::Return(dsERR_NONE));
+
+    status = m_LEDplugin->SetLEDState(State, success);
+    EXPECT_EQ(status, Core::ERROR_NONE);
+    EXPECT_TRUE(success);
+}
+
+/************Test case Details **************************
+** 1.GetLEDState with state set to be "ACTIVE" using comrpc
+*******************************************************/
+
+TEST_F(LEDControl_L2test, Get_LEDState_ACTIVE)
+{
+    Exchange::ILEDControl::LEDControlState LEDState;
+    uint32_t status = Core::ERROR_NONE;
+
+    EXPECT_CALL(*p_dsFPDMock, dsFPGetLEDState(::testing::_))
+        .WillOnce(::testing::DoAll(
+            ::testing::SetArgPointee<0>(dsFPD_LED_DEVICE_ACTIVE),
+            ::testing::Return(dsERR_NONE)));
+
+    status = m_LEDplugin->GetLEDState(LEDState);
+    EXPECT_EQ(status, Core::ERROR_NONE);
+
+    TEST_LOG("GetLEDState returned: %s", LEDState.state.c_str());
+}
+
+/************Test case Details **************************
+** 1.SetLEDState with state set to be "STANDBY" using comrpc
+*******************************************************/
+
+TEST_F(LEDControl_L2test, Set_LEDState_STANDBY)
+{
+    uint32_t status = Core::ERROR_NONE;
+    string State = "STANDBY";
+    bool success = false;
+
+    EXPECT_CALL(*p_dsFPDMock, dsFPSetLEDState(::testing::_))
+        .WillOnce(::testing::Return(dsERR_NONE));
+
+    status = m_LEDplugin->SetLEDState(State, success);
+    EXPECT_EQ(status, Core::ERROR_NONE);
+    EXPECT_TRUE(success);
+}
+
+/************Test case Details **************************
+** 1.GetLEDState with state set to be "STANDBY" using comrpc
+*******************************************************/
+
+TEST_F(LEDControl_L2test, Get_LEDState_STANDBY)
+{
+    Exchange::ILEDControl::LEDControlState LEDState;
+    uint32_t status = Core::ERROR_NONE;
+
+    EXPECT_CALL(*p_dsFPDMock, dsFPGetLEDState(::testing::_))
+        .WillOnce(::testing::DoAll(
+            ::testing::SetArgPointee<0>(dsFPD_LED_DEVICE_STANDBY),
+            ::testing::Return(dsERR_NONE)));
+
+    status = m_LEDplugin->GetLEDState(LEDState);
+    EXPECT_EQ(status, Core::ERROR_NONE);
+
+    TEST_LOG("GetLEDState returned: %s", LEDState.state.c_str());
+}
+
+/************Test case Details **************************
+** 1.SetLEDState with state set to be "WPS_CONNECTING" using comrpc
+*******************************************************/
+
+TEST_F(LEDControl_L2test, Set_LEDState_WPSCONNECTING)
+{
+    uint32_t status = Core::ERROR_NONE;
+    string State = "WPS_CONNECTING";
+    bool success = false;
+
+    EXPECT_CALL(*p_dsFPDMock, dsFPSetLEDState(::testing::_))
+        .WillOnce(::testing::Return(dsERR_NONE));
+
+    status = m_LEDplugin->SetLEDState(State, success);
+    EXPECT_EQ(status, Core::ERROR_NONE);
+    EXPECT_TRUE(success);
+}
+
+/************Test case Details **************************
+** 1.GetLEDState with state set to be "WPS_CONNECTING" using comrpc
+*******************************************************/
+
+TEST_F(LEDControl_L2test, Get_LEDState_WPSCONNECTING)
+{
+    Exchange::ILEDControl::LEDControlState LEDState;
+    uint32_t status = Core::ERROR_NONE;
+
+    EXPECT_CALL(*p_dsFPDMock, dsFPGetLEDState(::testing::_))
+        .WillOnce(::testing::DoAll(
+            ::testing::SetArgPointee<0>(dsFPD_LED_DEVICE_WPS_CONNECTING),
+            ::testing::Return(dsERR_NONE)));
+
+    status = m_LEDplugin->GetLEDState(LEDState);
+    EXPECT_EQ(status, Core::ERROR_NONE);
+
+    TEST_LOG("GetLEDState returned: %s", LEDState.state.c_str());
+}
+
+/************Test case Details **************************
+** 1.SetLEDState with state set to be "WPS_CONNECTED" using comrpc
+*******************************************************/
+
+TEST_F(LEDControl_L2test, Set_LEDState_CONNECTED)
+{
+    uint32_t status = Core::ERROR_NONE;
+    string State = "WPS_CONNECTED";
+    bool success = false;
+
+    EXPECT_CALL(*p_dsFPDMock, dsFPSetLEDState(::testing::_))
+        .WillOnce(::testing::Return(dsERR_NONE));
+
+    status = m_LEDplugin->SetLEDState(State, success);
+    EXPECT_EQ(status, Core::ERROR_NONE);
+    EXPECT_TRUE(success);
+}
+
+/************Test case Details **************************
+** 1.GetLEDState with state returned as "WPS_CONNECTED" using comrpc
+*******************************************************/
+
+TEST_F(LEDControl_L2test, Get_LEDState_WPSCONNECTED)
+{
+    Exchange::ILEDControl::LEDControlState LEDState;
+    uint32_t status = Core::ERROR_NONE;
+
+    EXPECT_CALL(*p_dsFPDMock, dsFPGetLEDState(::testing::_))
+        .WillOnce(::testing::DoAll(
+            ::testing::SetArgPointee<0>(dsFPD_LED_DEVICE_WPS_CONNECTED),
+            ::testing::Return(dsERR_NONE)));
+
+    status = m_LEDplugin->GetLEDState(LEDState);
+    EXPECT_EQ(status, Core::ERROR_NONE);
+
+    TEST_LOG("GetLEDState returned: %s", LEDState.state.c_str());
+}
+
+/************Test case Details **************************
+** 1.SetLEDState with state set to be "WPS_ERROR" using comrpc
+*******************************************************/
+
+TEST_F(LEDControl_L2test, Set_LEDState_ERROR)
+{
+    uint32_t status = Core::ERROR_NONE;
+    string State = "WPS_ERROR";
+    bool success = false;
+
+    EXPECT_CALL(*p_dsFPDMock, dsFPSetLEDState(::testing::_))
+        .WillOnce(::testing::Return(dsERR_NONE));
+
+    status = m_LEDplugin->SetLEDState(State, success);
+    EXPECT_EQ(status, Core::ERROR_NONE);
+    EXPECT_TRUE(success);
+}
+
+/************Test case Details **************************
+** 1.GetLEDState with state returned as "WPS_ERROR" using comrpc
+*******************************************************/
+
+TEST_F(LEDControl_L2test, Get_LEDState_ERROR)
+{
+    Exchange::ILEDControl::LEDControlState LEDState;
+    uint32_t status = Core::ERROR_NONE;
+
+    EXPECT_CALL(*p_dsFPDMock, dsFPGetLEDState(::testing::_))
+        .WillOnce(::testing::DoAll(
+            ::testing::SetArgPointee<0>(dsFPD_LED_DEVICE_WPS_ERROR),
+            ::testing::Return(dsERR_NONE)));
+
+    status = m_LEDplugin->GetLEDState(LEDState);
+    EXPECT_EQ(status, Core::ERROR_NONE);
+
+    TEST_LOG("GetLEDState returned: %s", LEDState.state.c_str());
+}
+
+/************Test case Details **************************
+** 1.SetLEDState with state set to be "FACTORY_RESET" using comrpc
+*******************************************************/
+
+TEST_F(LEDControl_L2test, Set_LEDState_FACTORYRESET)
+{
+    uint32_t status = Core::ERROR_NONE;
+    string State = "FACTORY_RESET";
+    bool success = false;
+
+    EXPECT_CALL(*p_dsFPDMock, dsFPSetLEDState(::testing::_))
+        .WillOnce(::testing::Return(dsERR_NONE));
+
+    status = m_LEDplugin->SetLEDState(State, success);
+    EXPECT_EQ(status, Core::ERROR_NONE);
+    EXPECT_TRUE(success);
+}
+
+/************Test case Details **************************
+** 1.GetLEDState with state returned as "DEVICE_FACTORY_RESET" using comrpc
+*******************************************************/
+
+TEST_F(LEDControl_L2test, Get_LEDState_FACTORYRESET)
+{
+    Exchange::ILEDControl::LEDControlState LEDState;
+    uint32_t status = Core::ERROR_NONE;
+
+    EXPECT_CALL(*p_dsFPDMock, dsFPGetLEDState(::testing::_))
+        .WillOnce(::testing::DoAll(
+            ::testing::SetArgPointee<0>(dsFPD_LED_DEVICE_FACTORY_RESET),
+            ::testing::Return(dsERR_NONE)));
+
+    status = m_LEDplugin->GetLEDState(LEDState);
+    EXPECT_EQ(status, Core::ERROR_NONE);
+
+    TEST_LOG("GetLEDState returned: %s", LEDState.state.c_str());
+}
+
+/************Test case Details **************************
+** 1.SetLEDState with state set to be "USB_UPGRADE" using comrpc
+*******************************************************/
+
+TEST_F(LEDControl_L2test, Set_LEDState_USBUPGRADE)
+{
+    uint32_t status = Core::ERROR_NONE;
+    string State = "USB_UPGRADE";
+    bool success = false;
+
+    EXPECT_CALL(*p_dsFPDMock, dsFPSetLEDState(::testing::_))
+        .WillOnce(::testing::Return(dsERR_NONE));
+
+    status = m_LEDplugin->SetLEDState(State, success);
+    EXPECT_EQ(status, Core::ERROR_NONE);
+    EXPECT_TRUE(success);
+}
+
+/************Test case Details **************************
+** 1.GetLEDState with state returned as "DEVICE_USB_UPGRADE" using comrpc
+*******************************************************/
+
+TEST_F(LEDControl_L2test, Get_LEDState_USBUPGRADE)
+{
+    Exchange::ILEDControl::LEDControlState LEDState;
+    uint32_t status = Core::ERROR_NONE;
+
+    EXPECT_CALL(*p_dsFPDMock, dsFPGetLEDState(::testing::_))
+        .WillOnce(::testing::DoAll(
+            ::testing::SetArgPointee<0>(dsFPD_LED_DEVICE_USB_UPGRADE),
+            ::testing::Return(dsERR_NONE)));
+
+    status = m_LEDplugin->GetLEDState(LEDState);
+    EXPECT_EQ(status, Core::ERROR_NONE);
+
+    TEST_LOG("GetLEDState returned: %s", LEDState.state.c_str());
+}
+
+/************Test case Details **************************
+** 1.SetLEDState with state set to be "DOWNLOAD_ERROR" using comrpc
+*******************************************************/
+
+TEST_F(LEDControl_L2test, Set_LEDState_DOWNLOADERROR)
+{
+    uint32_t status = Core::ERROR_NONE;
+    string State = "DOWNLOAD_ERROR";
+    bool success = false;
+
+    EXPECT_CALL(*p_dsFPDMock, dsFPSetLEDState(::testing::_))
+        .WillOnce(::testing::Return(dsERR_NONE));
+
+    status = m_LEDplugin->SetLEDState(State, success);
+    EXPECT_EQ(status, Core::ERROR_NONE);
+    EXPECT_TRUE(success);
+}
+
+/************Test case Details **************************
+** 1.GetLEDState with state returned as "SOFTWARE_DOWNLOAD_ERROR" using comrpc
+*******************************************************/
+
+TEST_F(LEDControl_L2test, Get_LEDState_DOWNLOADERROR)
+{
+    Exchange::ILEDControl::LEDControlState LEDState;
+    uint32_t status = Core::ERROR_NONE;
+
+    EXPECT_CALL(*p_dsFPDMock, dsFPGetLEDState(::testing::_))
+        .WillOnce(::testing::DoAll(
+            ::testing::SetArgPointee<0>(dsFPD_LED_DEVICE_SOFTWARE_DOWNLOAD_ERROR),
+            ::testing::Return(dsERR_NONE)));
+
+    status = m_LEDplugin->GetLEDState(LEDState);
+    EXPECT_EQ(status, Core::ERROR_NONE);
+
+    TEST_LOG("GetLEDState returned: %s", LEDState.state.c_str());
+}
+
+/************Test case Details **************************
+** 1.GetLEDState with state returned as "NONE" using comrpc
+*******************************************************/
+
+TEST_F(LEDControl_L2test, Get_LEDState_FPD_LED_DEVICE_NONE)
+{
+    Exchange::ILEDControl::LEDControlState LEDState;
+    uint32_t status = Core::ERROR_NONE;
+
+    EXPECT_CALL(*p_dsFPDMock, dsFPGetLEDState(::testing::_))
+        .WillOnce(::testing::DoAll(
+            ::testing::SetArgPointee<0>(dsFPD_LED_DEVICE_NONE),
+            ::testing::Return(dsERR_NONE)));
+
+    status = m_LEDplugin->GetLEDState(LEDState);
+    EXPECT_EQ(status, Core::ERROR_NONE);
+
+    TEST_LOG("GetLEDState returned: %s", LEDState.state.c_str());
+}
+
+/************Test case Details **************************
+** 1.SetLEDState with state set to be "NONE" using comrpc
+*******************************************************/
+
+TEST_F(LEDControl_L2test, Set_LEDState_NONE)
+{
+    uint32_t status = Core::ERROR_NONE;
+    string State = "NONE";
+    bool success = true;
+
+    status = m_LEDplugin->SetLEDState(State, success);
+    EXPECT_EQ(status, Core::ERROR_BAD_REQUEST);
+    EXPECT_FALSE(success);
+}
+
+/************Test case Details **************************
+** 1.GetLEDState with dsFPGetLEDState mock returning dsFPD_LED_DEVICE_MAX for Unsupported LED state using comrpc
+*******************************************************/
+
+TEST_F(LEDControl_L2test, Get_LEDState_defaultCase)
+{
+    Exchange::ILEDControl::LEDControlState LEDState;
+    uint32_t status = Core::ERROR_NONE;
+
+    EXPECT_CALL(*p_dsFPDMock, dsFPGetLEDState(::testing::_))
+        .WillOnce(::testing::DoAll(
+            ::testing::SetArgPointee<0>(dsFPD_LED_DEVICE_MAX),
+            ::testing::Return(dsERR_NONE)));
+
+    status = m_LEDplugin->GetLEDState(LEDState);
+    EXPECT_EQ(status, Core::ERROR_BAD_REQUEST);
+
+    TEST_LOG("GetLEDState returned: %s", LEDState.state.c_str());
+}
+
+/************Test case Details **************************
+** 1.GetLEDState with dsFPGetLEDState mock returning error using comrpc
+*******************************************************/
+
+TEST_F(LEDControl_L2test, Get_LEDState_Errorcase)
+{
+    Exchange::ILEDControl::LEDControlState LEDState;
+    uint32_t status = Core::ERROR_NONE;
+
+    EXPECT_CALL(*p_dsFPDMock, dsFPGetLEDState(::testing::_))
+        .WillOnce(::testing::Return(dsERR_GENERAL));
+
+    status = m_LEDplugin->GetLEDState(LEDState);
+    EXPECT_EQ(status, Core::ERROR_GENERAL);
+
+    TEST_LOG("GetLEDState returned: %s", LEDState.state.c_str());
+}
+
+/************Test case Details **************************
+** 1.SetLEDState with invalid parameter using comrpc
+*******************************************************/
+
+TEST_F(LEDControl_L2test, Set_LEDState_InvalidParameter)
+{
+    uint32_t status = Core::ERROR_NONE;
+    string State = "INVALID";
+    bool success = true;
+
+    status = m_LEDplugin->SetLEDState(State, success);
+    EXPECT_EQ(status, Core::ERROR_BAD_REQUEST);
+    EXPECT_FALSE(success);
+}
+
+/************Test case Details **************************
+** 1.SetLEDState with empty parameter using comrpc
+*******************************************************/
+
+TEST_F(LEDControl_L2test, Set_LEDState_emptyParameter)
+{
+    uint32_t status = Core::ERROR_NONE;
+    string State;
+    bool success = true;
+
+    status = m_LEDplugin->SetLEDState(State, success);
+    EXPECT_EQ(status, Core::ERROR_BAD_REQUEST);
+    EXPECT_FALSE(success);
+}
+
+/************Test case Details **************************
+** 1.SetLEDState with dsFPSetLEDState mock returning error using comrpc
+*******************************************************/
+
+TEST_F(LEDControl_L2test, Set_LEDState_dsFPSetLEDState_Error)
+{
+    uint32_t status = Core::ERROR_NONE;
+    string State = "DOWNLOAD_ERROR";
+    bool success = true;
+
+    EXPECT_CALL(*p_dsFPDMock, dsFPSetLEDState(::testing::_))
+        .WillOnce(::testing::Return(dsERR_GENERAL));
+
+    status = m_LEDplugin->SetLEDState(State, success);
+    EXPECT_EQ(status, Core::ERROR_GENERAL);
+    EXPECT_FALSE(success);
+}
+
+/************Test case Details **************************
+** 1.GetSupportedLEDStates with dsFPGetSupportedLEDStates mock raising exception using comrpc
+*******************************************************/
+
+TEST_F(LEDControl_L2test, dsFPGetSupportedLEDStates_RaiseException)
+{
+    uint32_t status = Core::ERROR_NONE;
+    bool success = false;
+    WPEFramework::RPC::IStringIterator* supportedLEDStates;
+
+    EXPECT_CALL(*p_dsFPDMock, dsFPGetSupportedLEDStates(::testing::_))
+        .WillOnce(::testing::Invoke([](unsigned int* states) {
+            throw std::runtime_error("Simulated Exception");
+            return dsERR_NONE;
+        }));
+
+    status = m_LEDplugin->GetSupportedLEDStates(supportedLEDStates, success);
+    EXPECT_EQ(status, Core::ERROR_GENERAL);
+    EXPECT_FALSE(success);
+}
+
+/************Test case Details **************************
+** 1.GetLEDState with dsFPGetLEDState mock raising exception using comrpc
+*******************************************************/
+
+TEST_F(LEDControl_L2test, dsFPGetLEDState_RaiseException)
+{
+    uint32_t status = Core::ERROR_NONE;
+    Exchange::ILEDControl::LEDControlState LEDState;
+    ;
+
+    EXPECT_CALL(*p_dsFPDMock, dsFPGetLEDState(::testing::_))
+        .WillOnce(::testing::Invoke([](dsFPDLedState_t* states) {
+            throw std::runtime_error("Simulated Exception");
+            return dsERR_NONE;
+        }));
+
+    status = m_LEDplugin->GetLEDState(LEDState);
+    EXPECT_EQ(status, Core::ERROR_GENERAL);
+}
+
+/************Test case Details **************************
+** 1.SetLEDState with dsFPSetLEDState mock raising exception using comrpc
+*******************************************************/
+
+TEST_F(LEDControl_L2test, dsFPSetLEDState_RaiseException)
+{
+    uint32_t status = Core::ERROR_NONE;
+    string State = "DOWNLOAD_ERROR";
+    bool success = true;
+
+    EXPECT_CALL(*p_dsFPDMock, dsFPSetLEDState(::testing::_))
+        .WillOnce(::testing::Invoke([](dsFPDLedState_t states) {
+            throw std::runtime_error("Simulated Exception");
+            return dsERR_NONE;
+        }));
+
+    status = m_LEDplugin->SetLEDState(State, success);
+    EXPECT_EQ(status, Core::ERROR_GENERAL);
+    EXPECT_FALSE(success);
+}


### PR DESCRIPTION
* RDK-55477 : Add L1 / L2 tests for LEDControl plugin

Reason for change: Adding L1/L2 test cases for latest COM-RPC supported LEDControl plugin.
Test Procedure: Run L2test to verify
Risks: Medium



* Update L2-tests.yml

* Update CMakeLists.txt

* Update CMakeLists.txt

* Update L2-tests.yml

* Update L2-tests.yml

* Update CMakeLists.txt

* Update LedControl_L2Test.cpp

* Update CMakeLists.txt

* Update L2-tests.yml

* Update CMakeLists.txt

* Update L2-tests.yml

* Update L2-tests.yml

* Update CMakeLists.txt

* Update L2-tests.yml

* Update L2-tests.yml

* Update L2-tests.yml

---------