### PR TITLE
RDKEMW-3905: Remove pwrmgr component changes

### DIFF
--- a/LEDControl/LEDControlImplementation.cpp
+++ b/LEDControl/LEDControlImplementation.cpp
@@ -21,8 +21,6 @@
 
 #include <algorithm>
 
-#include "rdk/iarmmgrs-hal/pwrMgr.h"
-
 #include "UtilsJsonRpc.h"
 #include "UtilsIarm.h"
 #include "dsFPD.h"


### PR DESCRIPTION
Reason for change: Depricate `pwrmgr` from iarmmgr 
Test Procedure: build and check
Risks: Low