### PR TITLE
RDKEMW-3905: Cleanup pwrmgr dependent component changes 

### DIFF
--- a/.github/workflows/L2-tests.yml
+++ b/.github/workflows/L2-tests.yml
@@ -156,7 +156,7 @@ jobs:
         run: |
           cd $GITHUB_WORKSPACE/entservices-apis
           patch -p1 < $GITHUB_WORKSPACE/entservices-testframework/patches/RDKEMW-1007.patch
-          cd -      
+          cd -
 
       - name: Build entservices-apis
         run: >
@@ -219,7 +219,6 @@ jobs:
           rdk/iarmbus/libIBusDaemon.h
           rdk/halif/deepsleep-manager/deepSleepMgr.h
           rdk/iarmmgrs-hal/mfrMgr.h
-          rdk/iarmmgrs-hal/pwrMgr.h
           rdk/iarmmgrs-hal/sysMgr.h
           network/wifiSrvMgrIarmIf.h
           network/netsrvmgrIarm.h

--- a/LEDControl/LEDControlImplementation.cpp
+++ b/LEDControl/LEDControlImplementation.cpp
@@ -21,8 +21,6 @@
 
 #include <algorithm>
 
-#include "rdk/iarmmgrs-hal/pwrMgr.h"
-
 #include "UtilsJsonRpc.h"
 #include "UtilsIarm.h"
 #include "dsFPD.h"


### PR DESCRIPTION
Reason for change: Deprecate pwrmgr from iarmmgr
Test Procedure: build and check
Risks: Low