### PR TITLE
RDKEMW-5739: LED booting pattern 

### DIFF
--- a/helpers/frontpanel.cpp
+++ b/helpers/frontpanel.cpp
@@ -180,7 +180,7 @@ namespace WPEFramework
 #endif
                     globalLedBrightness = device::FrontPanelIndicator::getInstance("Power").getBrightness();
                     LOGINFO("Power light brightness, %d, power status %d", globalLedBrightness, powerStatus);
-
+#if 0
                     for (uint i = 0; i < fpIndicators.size(); i++)
                     {
                         LOGWARN("Initializing light %s", fpIndicators.at(i).getName().c_str());
@@ -189,7 +189,9 @@ namespace WPEFramework
 
                         device::FrontPanelIndicator::getInstance(fpIndicators.at(i).getName()).setState(false);
                     }
-
+#else
+    LOGWARN("GSK: NOT Initializing light %s since we continue with bootloader patern", fpIndicators.at(i).getName().c_str());
+#endif
                     if (powerStatus)
                         device::FrontPanelIndicator::getInstance("Power").setState(true);
 

--- a/helpers/frontpanel.cpp
+++ b/helpers/frontpanel.cpp
@@ -171,6 +171,7 @@ namespace WPEFramework
                                 if (pwrStateCur == WPEFramework::Exchange::IPowerManager::POWER_STATE_ON)
                                     powerStatus = true;
                             }
+                            LOGINFO(" pwrStateCur %d, pwrStatePrev %d powerStatus=%d", pwrStateCur, pwrStatePrev, powerStatus);
                         }
                     }
 #endif
@@ -180,7 +181,7 @@ namespace WPEFramework
 #endif
                     globalLedBrightness = device::FrontPanelIndicator::getInstance("Power").getBrightness();
                     LOGINFO("Power light brightness, %d, power status %d", globalLedBrightness, powerStatus);
-#if 0
+#if 0 //Need to fix this logic based on the device type. 
                     for (uint i = 0; i < fpIndicators.size(); i++)
                     {
                         LOGWARN("Initializing light %s", fpIndicators.at(i).getName().c_str());
@@ -190,7 +191,7 @@ namespace WPEFramework
                         device::FrontPanelIndicator::getInstance(fpIndicators.at(i).getName()).setState(false);
                     }
 #else
-    LOGWARN("GSK: NOT Initializing light power since we continue with bootloader patern");
+                    LOGWARN("Power LED Initializing is not set since we continue with bootloader patern");
 #endif
                     if (powerStatus)
                         device::FrontPanelIndicator::getInstance("Power").setState(true);

--- a/helpers/frontpanel.cpp
+++ b/helpers/frontpanel.cpp
@@ -190,7 +190,7 @@ namespace WPEFramework
                         device::FrontPanelIndicator::getInstance(fpIndicators.at(i).getName()).setState(false);
                     }
 #else
-    LOGWARN("GSK: NOT Initializing light %s since we continue with bootloader patern", fpIndicators.at(i).getName().c_str());
+    LOGWARN("GSK: NOT Initializing light power since we continue with bootloader patern");
 #endif
                     if (powerStatus)
                         device::FrontPanelIndicator::getInstance("Power").setState(true);

--- a/helpers/frontpanel.cpp
+++ b/helpers/frontpanel.cpp
@@ -181,6 +181,7 @@ namespace WPEFramework
 #endif
                     globalLedBrightness = device::FrontPanelIndicator::getInstance("Power").getBrightness();
                     LOGINFO("Power light brightness, %d, power status %d", globalLedBrightness, powerStatus);
+
 #if 0 //Need to fix this logic based on the device type. 
                     for (uint i = 0; i < fpIndicators.size(); i++)
                     {


### PR DESCRIPTION


Reason for change: Power LED Initializing is not set from MW and continue with bootloader patern
Test Procedure: Refer RDKEMW-5739
Risks: High
Signed-off-by:gsanto722 grandhi_santoshkumar@comcast.com