### PR TITLE
RDKEMW-5739: LED booting pattern

### DIFF
--- a/helpers/frontpanel.cpp
+++ b/helpers/frontpanel.cpp
@@ -172,7 +172,7 @@ namespace WPEFramework
                                 if (pwrStateCur == WPEFramework::Exchange::IPowerManager::POWER_STATE_ON)
                                     powerStatus = true;
                             }
-                            LOGINFO(" pwrStateCur %d, pwrStatePrev %d powerStatus=%d", pwrStateCur, pwrStatePrev, powerStatus);
+                            LOGINFO("pwrStateCur[%d] pwrStatePrev[%d] powerStatus[%d]", pwrStateCur, pwrStatePrev, powerStatus);
                         }
                     }
 #endif


### PR DESCRIPTION
RDKEMW-5739: LED booting pattern

Reason for change: Power LED Initializing is not set from MW and continue with bootloader patern
Test Procedure: Refer RDKEMW-5739
Risks: High

Signed-off-by: yuvaramachandran_gurusamy <yuvaramachandran_gurusamy@comcast.com>