### PR TITLE
RDKEMW-5739: LED booting pattern

### DIFF
--- a/helpers/frontpanel.cpp
+++ b/helpers/frontpanel.cpp
@@ -172,7 +172,7 @@ namespace WPEFramework
                                 if (pwrStateCur == WPEFramework::Exchange::IPowerManager::POWER_STATE_ON)
                                     powerStatus = true;
                             }
-                            LOGINFO(" pwrStateCur %d, pwrStatePrev %d powerStatus=%d", pwrStateCur, pwrStatePrev, powerStatus);
+                            LOGINFO("pwrStateCur[%d] pwrStatePrev[%d] powerStatus[%d]", pwrStateCur, pwrStatePrev, powerStatus);
                         }
                     }
 #endif

--- a/helpers/frontpanel.cpp
+++ b/helpers/frontpanel.cpp
@@ -51,6 +51,7 @@ using PowerState = WPEFramework::Exchange::IPowerManager::PowerState;
 #include "UtilsLogging.h"
 #include "UtilssyncPersistFile.h"
 #include "PowerManagerInterface.h"
+#include "UtilsSearchRDKProfile.h"
 
 #define FP_SETTINGS_FILE_JSON "/opt/fp_service_preferences.json"
 
@@ -171,6 +172,7 @@ namespace WPEFramework
                                 if (pwrStateCur == WPEFramework::Exchange::IPowerManager::POWER_STATE_ON)
                                     powerStatus = true;
                             }
+                            LOGINFO(" pwrStateCur %d, pwrStatePrev %d powerStatus=%d", pwrStateCur, pwrStatePrev, powerStatus);
                         }
                     }
 #endif
@@ -181,16 +183,24 @@ namespace WPEFramework
                     globalLedBrightness = device::FrontPanelIndicator::getInstance("Power").getBrightness();
                     LOGINFO("Power light brightness, %d, power status %d", globalLedBrightness, powerStatus);
 
-                    for (uint i = 0; i < fpIndicators.size(); i++)
-                    {
-                        LOGWARN("Initializing light %s", fpIndicators.at(i).getName().c_str());
-                        if (powerStatus)
-                            device::FrontPanelIndicator::getInstance(fpIndicators.at(i).getName()).setBrightness(globalLedBrightness, false);
+		    profileType = searchRdkProfile();
+		    if (TV != profileType)
+		    {
+                        for (uint i = 0; i < fpIndicators.size(); i++)
+			{
+                            LOGWARN("Initializing light %s", fpIndicators.at(i).getName().c_str());
+			    if (powerStatus)
+                                device::FrontPanelIndicator::getInstance(fpIndicators.at(i).getName()).setBrightness(globalLedBrightness, false);
 
-                        device::FrontPanelIndicator::getInstance(fpIndicators.at(i).getName()).setState(false);
-                    }
+			    device::FrontPanelIndicator::getInstance(fpIndicators.at(i).getName()).setState(false);
+			}
+		    }
+		    else
+		    {
+                        LOGWARN("Power LED Initializing is not set since we continue with bootloader patern");
+		    }
 
-                    if (powerStatus)
+		    if (powerStatus)
                         device::FrontPanelIndicator::getInstance("Power").setState(true);
 
                 }


### PR DESCRIPTION
RDKEMW-5739: LED booting pattern

Reason for change: Power LED Initializing is not set from MW and continue with bootloader patern
Test Procedure: Refer RDKEMW-5739
Risks: High

Signed-off-by: yuvaramachandran_gurusamy [yuvaramachandran_gurusamy@comcast.com]