### PR TITLE
RDKEMW-6998: setBlinkLED not working when brightness is -1

### DIFF
--- a/helpers/frontpanel.cpp
+++ b/helpers/frontpanel.cpp
@@ -638,7 +638,7 @@ namespace WPEFramework
             try
             {
                 if (brightness == -1)
-                    brightness = device::FrontPanelIndicator::getInstance(ledIndicator.c_str()).getBrightness();
+                    brightness = device::FrontPanelIndicator::getInstance(ledIndicator.c_str()).getBrightness(true);
 
                 device::FrontPanelIndicator::getInstance(ledIndicator.c_str()).setBrightness(brightness, false);
             }


### PR DESCRIPTION
RDKEMW-6998: setBlinkLED not working when brightness is -1

Signed-off-by: yuvaramachandran_gurusamy <yuvaramachandran_gurusamy@comcast.com>