### PR TITLE
Feature/rdk 55825

### DIFF
--- a/MotionDetection/CMakeLists.txt
+++ b/MotionDetection/CMakeLists.txt
@@ -21,6 +21,7 @@ set(MODULE_NAME ${NAMESPACE}${PLUGIN_NAME})
 set(PLUGIN_MOTIONDETECTION_STARTUPORDER "" CACHE STRING "To configure startup order of MotionDetection plugin")
 
 find_package(${NAMESPACE}Plugins REQUIRED)
+find_package(Telemetry)
 
 add_library(${MODULE_NAME} SHARED
         MotionDetection.cpp
@@ -38,6 +39,11 @@ target_link_libraries(${MODULE_NAME} PRIVATE ${NAMESPACE}Plugins::${NAMESPACE}Pl
 else(RDK_SERVICES_L1_TEST)
         target_link_libraries(${MODULE_NAME} PRIVATE ${NAMESPACE}Plugins::${NAMESPACE}Plugins)
 endif(RDK_SERVICES_L1_TEST)
+
+if(TELEMETRY_FOUND)
+    target_link_libraries(${MODULE_NAME} PRIVATE ${TELEMETRY_LIBRARIES})
+    target_include_directories(${MODULE_NAME} PRIVATE ${TELEMETRY_INCLUDE_DIRS})
+endif()
 
 install(TARGETS ${MODULE_NAME}
         DESTINATION lib/${STORAGE_DIRECTORY}/plugins)

--- a/MotionDetection/MotionDetection.cpp
+++ b/MotionDetection/MotionDetection.cpp
@@ -25,6 +25,8 @@
 #include <syscall.h>
 #include "UtilsJsonRpc.h"
 
+#include <telemetry_busmessage_sender.h>
+
 #define NO_DETECTORS_FOUND    "0"
 #define MOTION_DETECTOR_INDEX "FP_MD"
 
@@ -455,6 +457,8 @@ namespace WPEFramework {
             params["index"] = index;
             params["mode"] = eventType;
             sendNotify("onMotionEvent", params);
+
+			t2_event_d("SYST_INFO_NotifyMotion", 1);
 
             m_lastEventTime = std::chrono::system_clock::now();
         }

--- a/cmake/FindTelemetry.cmake
+++ b/cmake/FindTelemetry.cmake
@@ -1,0 +1,35 @@
+# If not stated otherwise in this file or this component's license file the
+# following copyright and licenses apply:
+#
+# Copyright 2020 RDK Management
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# - Try to find Telemetry library
+# Once done this will define
+#  TELEMETRY_FOUND - System has Telemetry
+#  TELEMETRY_LIBRARIES - The libraries needed to use Telemetry
+#  TELEMETRY_INCLUDE_DIRS - The headers needed to use Telemetry
+
+find_package(PkgConfig)
+
+find_library(TELEMETRY_LIBRARIES NAMES telemetry_msgsender)
+find_path(TELEMETRY_INCLUDE_DIRS NAMES telemetry_busmessage_sender.h)
+
+include(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(TELEMETRY DEFAULT_MSG TELEMETRY_INCLUDE_DIRS TELEMETRY_LIBRARIES)
+
+mark_as_advanced(
+    TELEMETRY_FOUND
+    TELEMETRY_INCLUDE_DIRS
+    TELEMETRY_LIBRARIES)


### PR DESCRIPTION
RDK-55825: Adding t2 events for MotionDetection plugin
Reason for change:

- Adding t2 for "onMotionEvent: Notify onMotionEvent" search string

Test Procedure: see Jira ticket
Risks: Low
Priority: Medium