### PR TITLE
RDKEMW-22169 : use 4.0.8 tag of entservices-apis

### DIFF
--- a/.github/workflows/L1-tests.yml
+++ b/.github/workflows/L1-tests.yml
@@ -12,7 +12,7 @@ env:
   BUILD_TYPE: Debug
   REPO_NAME: "peripherals"
   THUNDER_REF: "R4.4.1"
-  INTERFACES_REF: "develop"
+  INTERFACES_REF: "4.0.8"
   AUTOMATICS_UNAME: ${{ secrets.AUTOMATICS_UNAME}}
   AUTOMATICS_PASSCODE: ${{ secrets. AUTOMATICS_PASSCODE}}
   ENABLE_CACHE: "false"

--- a/build_dependencies.sh
+++ b/build_dependencies.sh
@@ -31,7 +31,7 @@ git clone --branch  R4.4.3 https://github.com/rdkcentral/ThunderTools.git
 
 git clone --branch R4.4.1 https://github.com/rdkcentral/Thunder.git
 
-git clone --branch develop https://github.com/rdkcentral/entservices-apis.git
+git clone --branch 4.0.8 https://github.com/rdkcentral/entservices-apis.git
 
 git clone https://github.com/rdkcentral/entservices-testframework.git
 


### PR DESCRIPTION
Reason: Updated Thunder and ThunderTools version to 4.4.6.
Test Procedure: Refer ticket.
Risks: Medium.
Priority: P0.
Version: Patch